### PR TITLE
Fixed scd/ranges detection + calculate_zones() Refactor

### DIFF
--- a/auto-boost_2.5.py
+++ b/auto-boost_2.5.py
@@ -79,7 +79,7 @@ ranges = []
 src_file = Path(args.input).resolve()
 output_dir = src_file.parent
 tmp_dir = Path(args.temp).resolve() if args.temp is not None else output_dir / src_file.stem
-output_file = output_dir / f"{src_file.stem}_fastpass.mkv"
+output_file = tmp_dir / f"{src_file.stem}_fastpass.mkv"
 scenes_file = tmp_dir / "scenes.json"
 
 # Computation Parameters
@@ -403,14 +403,14 @@ def generate_zones(ranges: list, percentile_5_total: list, average: int, crf: fl
 def calculate_metrics(src_file, output_file, tmp_dir, ranges, skip, method):
     match method:
         case 1:
-            ssimu2_txt_path = output_dir / f"{src_file.stem}_ssimu2.log"
+            ssimu2_txt_path = tmp_dir / f"{src_file.stem}_ssimu2.log"
             calculate_ssimu2(src_file, output_file, ssimu2_txt_path, ranges, skip)
         case 2:
-            xpsnr_txt_path = output_dir / f"{src_file.stem}_xpsnr.log"
+            xpsnr_txt_path = tmp_dir / f"{src_file.stem}_xpsnr.log"
             calculate_xpsnr(src_file, output_file, xpsnr_txt_path)
         case 3 | 4:
-            xpsnr_txt_path = output_dir / f"{src_file.stem}_xpsnr.log"
-            ssimu2_txt_path = output_dir / f"{src_file.stem}_ssimu2.log"
+            xpsnr_txt_path = tmp_dir / f"{src_file.stem}_xpsnr.log"
+            ssimu2_txt_path = tmp_dir / f"{src_file.stem}_ssimu2.log"
             calculate_xpsnr(src_file, output_file, xpsnr_txt_path)
             calculate_ssimu2(src_file, output_file, ssimu2_txt_path, ranges, skip)
 
@@ -455,9 +455,9 @@ def calculate_zones(tmp_dir, ranges, method, cq, video_params, max_pos_dev, max_
             else:
                 method = 'minimum'
 
-            ssimu2_txt_path = output_dir / f"{src_file.stem}_ssimu2.log"
+            ssimu2_txt_path = tmp_dir / f"{src_file.stem}_ssimu2.log"
             ssimu2_scores, skip = get_ssimu2(ssimu2_txt_path)
-            xpsnr_txt_path = output_dir / f"{src_file.stem}_xpsnr.log"
+            xpsnr_txt_path = tmp_dir / f"{src_file.stem}_xpsnr.log"
             xpsnr_scores, _ = get_xpsnr(xpsnr_txt_path)
 
             calculation_zones_txt_path = tmp_dir / f"{method}_zones.txt"

--- a/auto-boost_2.5.py
+++ b/auto-boost_2.5.py
@@ -436,11 +436,11 @@ def calculate_zones(tmp_dir, ranges, method, cq, video_params, max_pos_dev, max_
         case 1 | 2:
             if method == 1:
                 metric = 'ssimu2'
-                metric_txt_path = output_dir / f'{src_file.stem}_{metric}.log'
+                metric_txt_path = tmp_dir / f'{src_file.stem}_{metric}.log'
                 metric_scores, skip = get_ssimu2(metric_txt_path)
             else:
                 metric = 'xpsnr'
-                metric_txt_path = output_dir / f'{src_file.stem}_{metric}.log'
+                metric_txt_path = tmp_dir / f'{src_file.stem}_{metric}.log'
                 metric_scores, skip = get_xpsnr(metric_txt_path)
 
             metric_zones_txt_path = tmp_dir / f'{metric}_zones.txt'

--- a/auto-boost_2.5.py
+++ b/auto-boost_2.5.py
@@ -262,6 +262,8 @@ def calculate_xpsnr(src_file, enc_file, xpsnr_txt_path) -> None:
         xpsnr_tmp_txt_path = Path(f"{src_file.stem}_xpsnr.log")
         src_file_dir = src_file.parent
         os.chdir(src_file_dir)
+    else:
+        xpsnr_tmp_txt_path = xpsnr_txt_path
 
     xpsnr_command = [
         'ffmpeg',
@@ -292,7 +294,8 @@ def calculate_xpsnr(src_file, enc_file, xpsnr_txt_path) -> None:
             print(f'XPSNR encountered an error:\n{e}')
             exit(-2)
 
-    shutil.move(xpsnr_tmp_txt_path, xpsnr_txt_path)
+    if IS_WINDOWS:
+        shutil.move(xpsnr_tmp_txt_path, xpsnr_txt_path)
 
 def get_xpsnr(xpsnr_txt_path):
     count=0

--- a/auto-boost_2.5.py
+++ b/auto-boost_2.5.py
@@ -79,7 +79,7 @@ output_dir = src_file.parent
 tmp_dir = Path(args.temp).resolve() if args.temp is not None else output_dir / src_file.stem
 output_file = output_dir / f"{src_file.stem}_fastpass.mkv"
 scenes_file = tmp_dir / "scenes.json"
-ranges = get_ranges(scenes_file)
+ranges = []
 crf = float(args.quality)
 base_deviation = float(args.deviation)
 max_pos_dev = args.max_positive_dev
@@ -128,6 +128,7 @@ def fast_pass(
         '-m', 'lsmash',
         '-c', 'mkvmerge',
         '--min-scene-len', '24',
+        '--scenes', scenes_file,
         '--sc-downscale-height', '720',
         '--set-thread-affinity', '2',
         '-e', 'svt-av1',
@@ -346,7 +347,7 @@ def generate_zones(ranges: list, percentile_5_total: list, average: int, crf: fl
     :param zones_txt_path: Path to the zones.txt file
     :type zones_txt_path: str
     :param video_params: custom encoder params for av1an
-    :type video_prams: str    
+    :type video_prams: str
     """
     zones_iter = 0
     
@@ -540,6 +541,7 @@ def calculate_zones(tmp_dir, ranges, zones, cq, video_params, max_pos_dev, max_n
 match stage:
     case 0:
         fast_pass(src_file, output_file, tmp_dir, preset, crf, workers, video_params)
+        ranges = get_ranges(scenes_file)
         calculate_metrics(src_file, output_file, tmp_dir, ranges, skip, metrics)
         calculate_zones(tmp_dir, ranges, zones, crf, video_params, max_pos_dev, max_neg_dev, base_deviation)
     case 1:
@@ -547,6 +549,7 @@ match stage:
     case 2:
         calculate_metrics(src_file, output_file, tmp_dir, ranges, skip, metrics)
     case 3:
+        ranges = get_ranges(scenes_file)
         calculate_zones(tmp_dir, ranges, zones, crf, video_params, max_pos_dev, max_neg_dev, base_deviation)
     case _:
         print(f"Stage argument invalid, exiting.")

--- a/auto-boost_2.5.py
+++ b/auto-boost_2.5.py
@@ -259,7 +259,7 @@ def calculate_ssimu2(src_file, enc_file, ssimu2_txt_path, ranges, skip):
 
 def calculate_xpsnr(src_file, enc_file, xpsnr_txt_path) -> None:
     if IS_WINDOWS:
-        xpsnr_txt_path = f"{src_file.stem}_xpsnr.log"
+        xpsnr_tmp_txt_path = Path(f"{src_file.stem}_xpsnr.log")
         src_file_dir = src_file.parent
         os.chdir(src_file_dir)
 
@@ -267,7 +267,7 @@ def calculate_xpsnr(src_file, enc_file, xpsnr_txt_path) -> None:
         'ffmpeg',
         '-i', src_file,
         '-i', enc_file,
-        '-lavfi', f'xpsnr=stats_file={xpsnr_txt_path}',
+        '-lavfi', f'xpsnr=stats_file={str(xpsnr_tmp_txt_path)}',
         '-f', 'null', NULL_DEVICE
     ]
 
@@ -291,6 +291,8 @@ def calculate_xpsnr(src_file, enc_file, xpsnr_txt_path) -> None:
         except subprocess.CalledProcessError as e:
             print(f'XPSNR encountered an error:\n{e}')
             exit(-2)
+
+    shutil.move(xpsnr_tmp_txt_path, xpsnr_txt_path)
 
 def get_xpsnr(xpsnr_txt_path):
     count=0

--- a/compile_latest.py
+++ b/compile_latest.py
@@ -1,0 +1,18 @@
+import PyInstaller.__main__
+from os import listdir
+from os.path import dirname, realpath
+
+pwd: str = dirname(realpath(__file__))
+files: list[str] = listdir(pwd)
+latest: tuple[str, float] = ("", 0.0)
+for file in files:
+    if file.endswith(".py") and file[-4].isdigit():
+        if float(file[-6:-3]) > latest[1]:
+            latest = (file, float(file[-6:-3]))
+
+PyInstaller.__main__.run([
+    latest[0],
+    '--onefile',
+    '--hidden-import', 'concurrent',
+    '--hidden-import', 'concurrent.futures'
+])


### PR DESCRIPTION
auto-boost_2.5 would expect a scenes.json file already in the temporary directory.
I added the '--scenes' to the fast_av1an_command so it would generate it itself.
I moved the get_ranges() function to right after the fast_pass() occurrences so there would be for sure a scenes.json file in the temp directory.
Also the calculate_metrics() and the calculate_ssimu2() don't use ranges but i left it in case it would be usefull in the future.

Edit:
In commit [47b81fb](https://github.com/nekotrix/auto-boost-algorithm/pull/16/commits/47b81fb175797034b2b21cba30796dca79b00c25) I have made significant changes that i should adress here.

The calculate_zones() function was refactored to merge the SSIMU2 and XPSNR parts together and the Multiplication and Minimum parts together also because they shared a lot of similar code.
To fully refactor the function,
- Replaced the "metrics" and "zones" arguments to a "method" argument because they were dependent on each other but not linked.
- Renamed the "zones" variable to "method" to make it less ambiguous.
- Changed the get_xpsnr() function to make it more similar to the get_ssimu2() function. They now both return scores and skip. (As skip is not used by xpsnr it is set to 1)
- Reorganized lightly the argument parsing section to make it more readable and comply with the new "method" variable.

Other change:
- Changed the SSIMU2 tqdm unit from "iterations" to "frames"