### PR TITLE
Fix compatibility with latest vstools

### DIFF
--- a/Auto-Boost-Essential/Auto-Boost-Essential.py
+++ b/Auto-Boost-Essential/Auto-Boost-Essential.py
@@ -258,7 +258,7 @@ if not os.path.exists(vpy_file):
     with open(vpy_file, 'w') as file:          
         file.write(
 f"""
-from vstools import vs, core, depth, DitherType, set_output
+from vstools import vs, core, depth, DitherType
 core.max_cache_size = 1024
 src = core.ffms2.Source(source=r"{src_file}", cachefile=r"{cache_file}")
 bit_to_format = {{
@@ -274,7 +274,7 @@ bit_to_dither = {{
 fmt = bit_to_format.get(src.format.bits_per_sample, vs.YUV420P16)
 dt = bit_to_dither.get(src.format.bits_per_sample, DitherType.RANDOM)
 src = depth(src.resize.Bilinear(format=fmt), 10, dither_type=dt)
-set_output(src)
+src.set_output()
 """
         )
 


### PR DESCRIPTION
This PR updates Auto-Boost-Essential to work with the latest `vstools` releases.

### Changes

- Remove the deprecated `set_output` import.
- Replace `set_output(src)` with `src.set_output()`.

`set_output` is no longer exported by recent versions of `vstools`, while `VideoNode.set_output()` is the native VapourSynth API and provides the same behavior.

This fixes the following error when running the script with recent versions of `vstools`:

```text
ImportError: cannot import name 'set_output' from 'vstools'
```

### Tested with

- Python 3.12.13
- VapourSynth R78
- vstools 3.1.0